### PR TITLE
[model][control] refactoring

### DIFF
--- a/src/control/manipulator_controller.cpp
+++ b/src/control/manipulator_controller.cpp
@@ -91,7 +91,7 @@ void ManipulatorController::sendCmd()
   tau_by_thrust_msg.header.stamp = ros::Time::now();
   // sensor_msgs::JointState rnea_solution_msg;
   // rnea_solution_msg.header.stamp = ros::Time::now();
-  Eigen::VectorXd curr_q = dragon_arm_robot_model_->getCurrentJointPositions();
+  Eigen::VectorXd curr_q = joint_trajectory_generator_->getCurrentQ();
   Eigen::VectorXd curr_target_thrust = trajectory_generator_->getCurrentTargetThrust();
   Eigen::VectorXd tau_by_thrust = pinocchio_robot_model_->computeTauExtByThrustDerivative(curr_q) * curr_target_thrust;
 

--- a/src/model/manipulator_model.cpp
+++ b/src/model/manipulator_model.cpp
@@ -26,8 +26,6 @@ void ManipulatorRobotModel::updateRobotModelImpl(const KDL::JntArray& joint_posi
   aerial_robot_model::RobotModel::updateRobotModelImpl(joint_positions);
 
   Eigen::VectorXd curr_q = parseJointState(joint_positions);
-
-  pinocchio::framesForwardKinematics(*pinocchio_model_, *pinocchio_data_, curr_q_);
 }
 
 Eigen::VectorXd ManipulatorRobotModel::parseJointState(const sensor_msgs::JointState& joint_state)


### PR DESCRIPTION
- do not run frame fk in joint state callback not to violate multithreading
- get current joint angle not from robot model plugin but from joint trajectory generator
